### PR TITLE
Initial support for disabling V8's JIT

### DIFF
--- a/patches/0001-switch-to-fstack-protector-strong.patch
+++ b/patches/0001-switch-to-fstack-protector-strong.patch
@@ -1,7 +1,7 @@
 From 8dca4d6657adf7d6da954ff016ccab13a46312df Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 26 Dec 2018 10:20:24 -0500
-Subject: [PATCH 01/37] switch to -fstack-protector-strong
+Subject: [PATCH 01/38] switch to -fstack-protector-strong
 
 ---
  build/config/compiler/BUILD.gn | 6 +-----

--- a/patches/0002-enable-fwrapv-in-Clang-for-non-UBSan-builds.patch
+++ b/patches/0002-enable-fwrapv-in-Clang-for-non-UBSan-builds.patch
@@ -1,7 +1,7 @@
 From 1df288be65aa31f12c4114e0dad102bcd0c9cf5c Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 22 Dec 2016 07:15:34 -0500
-Subject: [PATCH 02/37] enable -fwrapv in Clang for non-UBSan builds
+Subject: [PATCH 02/38] enable -fwrapv in Clang for non-UBSan builds
 
 ---
  build/config/compiler/BUILD.gn | 4 ++++

--- a/patches/0003-enable-ftrivial-auto-var-init-zero.patch
+++ b/patches/0003-enable-ftrivial-auto-var-init-zero.patch
@@ -1,7 +1,7 @@
 From f9c4955c36961dbea93eb088cd03af402f39ac75 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 8 Apr 2020 20:48:17 -0400
-Subject: [PATCH 03/37] enable -ftrivial-auto-var-init=zero
+Subject: [PATCH 03/38] enable -ftrivial-auto-var-init=zero
 
 ---
  build/config/compiler/BUILD.gn | 4 ++++

--- a/patches/0004-disable-broken-warning-for-auto-var-init.patch
+++ b/patches/0004-disable-broken-warning-for-auto-var-init.patch
@@ -1,7 +1,7 @@
 From c67579c74be974413f19fca318d055da51aa6985 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 21 May 2020 14:07:54 -0400
-Subject: [PATCH 04/37] disable broken warning for auto var init
+Subject: [PATCH 04/38] disable broken warning for auto var init
 
 ---
  build/config/compiler/BUILD.gn | 2 +-

--- a/patches/0005-disable-seed-based-field-trials.patch
+++ b/patches/0005-disable-seed-based-field-trials.patch
@@ -1,7 +1,7 @@
 From b5f2dd85af55a25a4dead92c24e555ccb5354680 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 25 Dec 2018 16:19:51 -0500
-Subject: [PATCH 05/37] disable seed-based field trials
+Subject: [PATCH 05/38] disable seed-based field trials
 
 ---
  components/variations/service/variations_field_trial_creator.cc | 2 ++

--- a/patches/0006-disable-navigation-error-correction-by-default.patch
+++ b/patches/0006-disable-navigation-error-correction-by-default.patch
@@ -1,7 +1,7 @@
 From 7bacda95b4da5638f192840054e44f62b70f56aa Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 23 Nov 2016 08:29:58 -0500
-Subject: [PATCH 06/37] disable navigation error correction by default
+Subject: [PATCH 06/38] disable navigation error correction by default
 
 ---
  chrome/browser/net/profile_network_context_service.cc | 2 +-

--- a/patches/0007-disable-network-prediction-by-default.patch
+++ b/patches/0007-disable-network-prediction-by-default.patch
@@ -1,7 +1,7 @@
 From 95d2641154e8e74329f53b31589628a9881d50e1 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 23 Nov 2016 08:31:44 -0500
-Subject: [PATCH 07/37] disable network prediction by default
+Subject: [PATCH 07/38] disable network prediction by default
 
 ---
  chrome/browser/net/prediction_options.h | 2 +-

--- a/patches/0008-disable-hyperlink-auditing-by-default.patch
+++ b/patches/0008-disable-hyperlink-auditing-by-default.patch
@@ -1,7 +1,7 @@
 From 5e34b41045550aa2552661cc6d9e60dab2631fb5 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sat, 26 Nov 2016 14:57:22 -0500
-Subject: [PATCH 08/37] disable hyperlink auditing by default
+Subject: [PATCH 08/38] disable hyperlink auditing by default
 
 ---
  chrome/browser/chrome_content_browser_client.cc | 2 +-

--- a/patches/0009-disable-showing-popular-sites-by-default.patch
+++ b/patches/0009-disable-showing-popular-sites-by-default.patch
@@ -1,7 +1,7 @@
 From 44d3df3ddfd670c358a9d827691528ce26c16484 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 6 Mar 2018 00:27:41 -0500
-Subject: [PATCH 09/37] disable showing popular sites by default
+Subject: [PATCH 09/38] disable showing popular sites by default
 
 ---
  components/ntp_tiles/features.cc | 4 ++--

--- a/patches/0010-disable-article-suggestions-feature-by-default.patch
+++ b/patches/0010-disable-article-suggestions-feature-by-default.patch
@@ -1,7 +1,7 @@
 From cabbec59d8c915b05970117a5d589c1c7cf5d892 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 8 Mar 2018 22:43:12 -0500
-Subject: [PATCH 10/37] disable article suggestions feature by default
+Subject: [PATCH 10/38] disable article suggestions feature by default
 
 ---
  components/feed/core/shared_prefs/pref_names.cc | 4 ++--

--- a/patches/0011-disable-prefetching-suggested-pages-by-default.patch
+++ b/patches/0011-disable-prefetching-suggested-pages-by-default.patch
@@ -1,7 +1,7 @@
 From 84cde48a5ac5c33565ca8ab1e94f6163d9b2fd5a Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 12 Jul 2019 04:10:21 -0400
-Subject: [PATCH 11/37] disable prefetching suggested pages by default
+Subject: [PATCH 11/38] disable prefetching suggested pages by default
 
 ---
  components/offline_pages/core/offline_page_feature.cc | 2 +-

--- a/patches/0012-disable-sensors-access-by-default.patch
+++ b/patches/0012-disable-sensors-access-by-default.patch
@@ -1,7 +1,7 @@
 From 56db17dbe7a1fbae49b77eb46ed096800761731b Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 16 Jun 2019 15:57:29 -0400
-Subject: [PATCH 12/37] disable sensors access by default
+Subject: [PATCH 12/38] disable sensors access by default
 
 ---
  .../content_settings/core/browser/content_settings_registry.cc  | 2 +-

--- a/patches/0013-disable-third-party-cookies-by-default.patch
+++ b/patches/0013-disable-third-party-cookies-by-default.patch
@@ -1,7 +1,7 @@
 From 4df913410b154b48b92bc3e77e0e32653e28a6bc Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 16 Jun 2019 16:01:31 -0400
-Subject: [PATCH 13/37] disable third party cookies by default
+Subject: [PATCH 13/38] disable third party cookies by default
 
 ---
  components/content_settings/core/browser/cookie_settings.cc | 2 +-

--- a/patches/0014-disable-background-sync-by-default.patch
+++ b/patches/0014-disable-background-sync-by-default.patch
@@ -1,7 +1,7 @@
 From 63d08e3a51289516976d77d6445560067a90de4a Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 16 Jun 2019 21:57:26 -0400
-Subject: [PATCH 14/37] disable background sync by default
+Subject: [PATCH 14/38] disable background sync by default
 
 ---
  .../content_settings/core/browser/content_settings_registry.cc  | 2 +-

--- a/patches/0015-disable-payment-support-by-default.patch
+++ b/patches/0015-disable-payment-support-by-default.patch
@@ -1,7 +1,7 @@
 From 9b21e677826c28ec24ef5ee50b91fb4644ab4228 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 18 Jun 2019 22:28:53 -0400
-Subject: [PATCH 15/37] disable payment support by default
+Subject: [PATCH 15/38] disable payment support by default
 
 ---
  components/payments/core/payment_prefs.cc | 2 +-

--- a/patches/0016-disable-media-router-media-remoting-by-default.patch
+++ b/patches/0016-disable-media-router-media-remoting-by-default.patch
@@ -1,7 +1,7 @@
 From 86bdaa119ff36362785a8df777b458031e7a579f Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 4 Jul 2019 18:11:27 -0400
-Subject: [PATCH 16/37] disable media router media remoting by default
+Subject: [PATCH 16/38] disable media router media remoting by default
 
 ---
  chrome/browser/profiles/profile.cc | 2 +-

--- a/patches/0017-disable-media-router-by-default.patch
+++ b/patches/0017-disable-media-router-by-default.patch
@@ -1,7 +1,7 @@
 From 8b21dded7e27c79db158edc905185bb81fd12fbb Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 4 Jul 2019 19:08:52 -0400
-Subject: [PATCH 17/37] disable media router by default
+Subject: [PATCH 17/38] disable media router by default
 
 ---
  chrome/browser/media/router/media_router_feature.cc | 2 +-

--- a/patches/0018-disable-offering-translations-by-default.patch
+++ b/patches/0018-disable-offering-translations-by-default.patch
@@ -1,7 +1,7 @@
 From 66a850b363a3c66e5ecbbba48f0a8f9c342d9002 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 12 Jul 2019 03:58:01 -0400
-Subject: [PATCH 18/37] disable offering translations by default
+Subject: [PATCH 18/38] disable offering translations by default
 
 ---
  chrome/browser/ui/browser_ui_prefs.cc | 2 +-

--- a/patches/0019-disable-browser-sign-in-feature-by-default.patch
+++ b/patches/0019-disable-browser-sign-in-feature-by-default.patch
@@ -1,7 +1,7 @@
 From e5e124d28a598e2939ee80c4e8d75d9a3d937d11 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 12 Jul 2019 04:23:18 -0400
-Subject: [PATCH 19/37] disable browser sign in feature by default
+Subject: [PATCH 19/38] disable browser sign in feature by default
 
 ---
  chrome/browser/signin/account_consistency_mode_manager.cc       | 2 +-

--- a/patches/0020-disable-browser-autologin-by-default.patch
+++ b/patches/0020-disable-browser-autologin-by-default.patch
@@ -1,7 +1,7 @@
 From ca573fadf890c1e641afbd708104be19ac3fdad1 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 22 Mar 2020 03:07:08 -0400
-Subject: [PATCH 20/37] disable browser autologin by default
+Subject: [PATCH 20/38] disable browser autologin by default
 
 ---
  .../signin/internal/identity_manager/primary_account_manager.cc | 2 +-

--- a/patches/0021-disable-safe-browsing-reporting-opt-in-by-default.patch
+++ b/patches/0021-disable-safe-browsing-reporting-opt-in-by-default.patch
@@ -1,7 +1,7 @@
 From 9ee408e0f606fba05588ac200af2713ada064d9d Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 12 Jul 2019 05:22:11 -0400
-Subject: [PATCH 21/37] disable safe browsing reporting opt-in by default
+Subject: [PATCH 21/38] disable safe browsing reporting opt-in by default
 
 ---
  components/safe_browsing/core/common/safe_browsing_prefs.cc | 2 +-

--- a/patches/0022-disable-unused-safe-browsing-option-by-default.patch
+++ b/patches/0022-disable-unused-safe-browsing-option-by-default.patch
@@ -1,7 +1,7 @@
 From 16b8b86b6826ab8d28ad55b0d333bf7501d443ec Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 12 Mar 2020 13:01:02 -0400
-Subject: [PATCH 22/37] disable unused safe browsing option by default
+Subject: [PATCH 22/38] disable unused safe browsing option by default
 
 Safe Browsing is currently a no-op due to the lack of Play Services, and
 support for using the local database backend hasn't been implemented.

--- a/patches/0023-enable-prefetch-privacy-changes-by-default.patch
+++ b/patches/0023-enable-prefetch-privacy-changes-by-default.patch
@@ -1,7 +1,7 @@
 From a5dc88f5defb3077f6881a3f425e1b6ff8861ea3 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 23 Oct 2020 23:59:13 -0400
-Subject: [PATCH 23/37] enable prefetch privacy changes by default
+Subject: [PATCH 23/38] enable prefetch privacy changes by default
 
 ---
  third_party/blink/common/features.cc | 2 +-

--- a/patches/0024-enable-user-agent-freeze-by-default.patch
+++ b/patches/0024-enable-user-agent-freeze-by-default.patch
@@ -1,7 +1,7 @@
 From f56f478b22b135cba39f0e3b5140581811151700 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 3 Mar 2021 13:42:41 -0500
-Subject: [PATCH 24/37] enable user agent freeze by default
+Subject: [PATCH 24/38] enable user agent freeze by default
 
 ---
  third_party/blink/common/features.cc | 2 +-

--- a/patches/0025-enable-split-cache-by-default.patch
+++ b/patches/0025-enable-split-cache-by-default.patch
@@ -1,7 +1,7 @@
 From dd7d64ffbc4744ab39c9c06f6b408d297f1634a9 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 23 Dec 2020 06:00:50 -0500
-Subject: [PATCH 25/37] enable split cache by default
+Subject: [PATCH 25/38] enable split cache by default
 
 ---
  net/base/features.cc | 2 +-

--- a/patches/0026-enable-partitioning-connections-by-default.patch
+++ b/patches/0026-enable-partitioning-connections-by-default.patch
@@ -1,7 +1,7 @@
 From 9764658ef7f9444be0036a634eee615c2a7b93c2 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Mon, 8 Mar 2021 16:53:47 -0500
-Subject: [PATCH 26/37] enable partitioning connections by default
+Subject: [PATCH 26/38] enable partitioning connections by default
 
 ---
  net/base/features.cc | 12 ++++++------

--- a/patches/0027-enable-dubious-Do-Not-Track-feature-by-default.patch
+++ b/patches/0027-enable-dubious-Do-Not-Track-feature-by-default.patch
@@ -1,7 +1,7 @@
 From 28c3fcc35bb1a350062701638a0d736745060af3 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 1 Aug 2017 11:16:11 -0400
-Subject: [PATCH 27/37] enable dubious Do Not Track feature by default
+Subject: [PATCH 27/38] enable dubious Do Not Track feature by default
 
 ---
  chrome/browser/ui/browser_ui_prefs.cc | 2 +-

--- a/patches/0028-disable-autofill-server-communication-by-default.patch
+++ b/patches/0028-disable-autofill-server-communication-by-default.patch
@@ -1,7 +1,7 @@
 From 4599525498505a30f76e1f47547360840c8d63f7 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 1 Dec 2020 00:56:57 -0500
-Subject: [PATCH 28/37] disable autofill server communication by default
+Subject: [PATCH 28/38] disable autofill server communication by default
 
 ---
  components/autofill/core/common/autofill_features.cc | 2 +-

--- a/patches/0029-disable-component-updater-pings-by-default.patch
+++ b/patches/0029-disable-component-updater-pings-by-default.patch
@@ -1,7 +1,7 @@
 From a2d0a249e541b00df292d4dea3d5be5988dcbe39 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 27 Nov 2020 03:56:29 -0500
-Subject: [PATCH 29/37] disable component updater pings by default
+Subject: [PATCH 29/38] disable component updater pings by default
 
 ---
  .../component_updater_command_line_config_policy.h              | 2 +-

--- a/patches/0030-mark-non-secure-origins-as-dangerous.patch
+++ b/patches/0030-mark-non-secure-origins-as-dangerous.patch
@@ -1,7 +1,7 @@
 From 1490d51356f0e408b36fdaa84a19c2d2f8e0a8a3 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 20 Oct 2017 21:20:50 -0400
-Subject: [PATCH 30/37] mark non-secure origins as dangerous
+Subject: [PATCH 30/38] mark non-secure origins as dangerous
 
 ---
  components/security_state/core/security_state.cc | 2 +-

--- a/patches/0031-stub-out-the-battery-status-API.patch
+++ b/patches/0031-stub-out-the-battery-status-API.patch
@@ -1,7 +1,7 @@
 From 48895fc1b42c9c09448a3f7c64cf0b77bb13d727 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Mon, 17 Jun 2019 11:29:21 -0400
-Subject: [PATCH 31/37] stub out the battery status API
+Subject: [PATCH 31/38] stub out the battery status API
 
 Pretend that the device is always plugged in and fully charged.
 ---

--- a/patches/0032-always-use-local-new-tab-page.patch
+++ b/patches/0032-always-use-local-new-tab-page.patch
@@ -1,7 +1,7 @@
 From 6ee0973b85962824a51f4cf809fe185bd420e9c0 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Mon, 17 Jun 2019 13:14:22 -0400
-Subject: [PATCH 32/37] always use local new tab page
+Subject: [PATCH 32/38] always use local new tab page
 
 ---
  chrome/browser/search/search.cc | 2 +-

--- a/patches/0033-disable-trivial-subdomain-hiding.patch
+++ b/patches/0033-disable-trivial-subdomain-hiding.patch
@@ -1,7 +1,7 @@
 From 7b8ef671d82af6e5dde9e80bee60d3c2aed5d932 Mon Sep 17 00:00:00 2001
 From: JTL <jtl@teamclassified.ca>
 Date: Sat, 21 Dec 2019 04:04:24 +0000
-Subject: [PATCH 33/37] disable trivial subdomain hiding
+Subject: [PATCH 33/38] disable trivial subdomain hiding
 
 ---
  components/url_formatter/url_formatter.cc | 3 +--

--- a/patches/0034-disable-trials-of-privacy-aware-analytics-advertisin.patch
+++ b/patches/0034-disable-trials-of-privacy-aware-analytics-advertisin.patch
@@ -1,7 +1,7 @@
 From 4acf4f6e7073619d55597ff385b18446261641ac Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 4 Aug 2021 03:29:04 -0400
-Subject: [PATCH 34/37] disable trials of privacy-aware analytics/advertising
+Subject: [PATCH 34/38] disable trials of privacy-aware analytics/advertising
  APIs
 
 ---

--- a/patches/0035-Hexavalent-set-webrtc-to-private-but-usable-default.patch
+++ b/patches/0035-Hexavalent-set-webrtc-to-private-but-usable-default.patch
@@ -1,7 +1,7 @@
 From 3d8ac982f4d937f38296c7cd6db4ca4da1f47c88 Mon Sep 17 00:00:00 2001
 From: flawedworld <flawedworld@flawed.world>
 Date: Sat, 14 Aug 2021 19:47:24 +0100
-Subject: [PATCH 35/37] Hexavalent: set webrtc to private but usable default
+Subject: [PATCH 35/38] Hexavalent: set webrtc to private but usable default
 
 ---
  chrome/browser/ui/browser_ui_prefs.cc | 2 +-

--- a/patches/0036-Debian-disable-the-google-api-key-warning-when-those.patch
+++ b/patches/0036-Debian-disable-the-google-api-key-warning-when-those.patch
@@ -1,7 +1,7 @@
 From ae50720ca3e4a5f5cd98c2c47d22ff6c950d81f7 Mon Sep 17 00:00:00 2001
 From: Michael Gilbert <mgilbert@debian.org>
 Date: Sun, 15 Aug 2021 05:08:49 +0100
-Subject: [PATCH 36/37] Debian: disable the google api key warning when those
+Subject: [PATCH 36/38] Debian: disable the google api key warning when those
  aren't found
 
 ---

--- a/patches/0037-Hexavalent-Make-HTTPS-only-mode-the-default.patch
+++ b/patches/0037-Hexavalent-Make-HTTPS-only-mode-the-default.patch
@@ -1,7 +1,7 @@
 From 2bc349ffe05859d9ce1a1302ade24e26ef668fa5 Mon Sep 17 00:00:00 2001
 From: qua3k <cliffmaceyak@gmail.com>
 Date: Mon, 18 Oct 2021 17:18:52 -0400
-Subject: [PATCH 37/37] Hexavalent: Make HTTPS-only mode the default
+Subject: [PATCH 37/38] Hexavalent: Make HTTPS-only mode the default
 
 ---
  chrome/browser/ui/browser_ui_prefs.cc | 2 +-

--- a/patches/0038-Initial-support-for-disabling-V8-s-JIT.patch
+++ b/patches/0038-Initial-support-for-disabling-V8-s-JIT.patch
@@ -1,0 +1,143 @@
+From decfda3a844d0964ed40e4183b699785c6ab9257 Mon Sep 17 00:00:00 2001
+From: qua3k <cliffmaceyak@gmail.com>
+Date: Tue, 19 Oct 2021 07:36:10 -0400
+Subject: [PATCH 38/38] Initial support for disabling V8's JIT
+
+---
+ chrome/browser/about_flags.cc              | 5 +++++
+ chrome/browser/flag-metadata.json          | 7 +++++++
+ chrome/browser/flag-never-expire-list.json | 1 +
+ chrome/browser/flag_descriptions.cc        | 5 +++++
+ chrome/browser/flag_descriptions.h         | 3 +++
+ gin/gin_features.cc                        | 3 +++
+ gin/gin_features.h                         | 1 +
+ gin/v8_initializer.cc                      | 4 ++++
+ 8 files changed, 29 insertions(+)
+
+diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
+index e50714dc9f4f8..369f5341a40b0 100644
+--- a/chrome/browser/about_flags.cc
++++ b/chrome/browser/about_flags.cc
+@@ -152,6 +152,7 @@
+ #include "device/gamepad/public/cpp/gamepad_features.h"
+ #include "device/vr/buildflags/buildflags.h"
+ #include "extensions/buildflags/buildflags.h"
++#include "gin/gin_features.h"
+ #include "gpu/config/gpu_finch_features.h"
+ #include "gpu/config/gpu_switches.h"
+ #include "media/audio/audio_features.h"
+@@ -5063,6 +5064,10 @@ const FeatureEntry kFeatureEntries[] = {
+      FEATURE_VALUE_TYPE(
+          lookalikes::features::kDetectTargetEmbeddingLookalikes)},
+ 
++    {"disable-v8-jit", flag_descriptions::kV8NoJITName,
++     flag_descriptions::kV8NoJITDescription, kOsDesktop,
++     FEATURE_VALUE_TYPE(features::kV8NoJIT)},
++
+     {"disable-process-reuse", flag_descriptions::kDisableProcessReuse,
+      flag_descriptions::kDisableProcessReuseDescription, kOsDesktop,
+      FEATURE_VALUE_TYPE(features::kDisableProcessReuse)},
+diff --git a/chrome/browser/flag-metadata.json b/chrome/browser/flag-metadata.json
+index a670bf1f6a828..ba928eb518bd7 100644
+--- a/chrome/browser/flag-metadata.json
++++ b/chrome/browser/flag-metadata.json
+@@ -1134,6 +1134,13 @@
+     // issues.
+     "expiry_milestone": -1
+   },
++  {
++    "name": "disable-v8-jit",
++    "owners": [ "cliffmaceyak@gmail.com" ],
++    // This flag does not expire because it allows users to disable the
++    // V8 Just-In-Time compiler.
++    "expiry_milestone": -1
++  },
+   {
+     "name": "disable-virtual-keyboard",
+     "owners": [ "myy", "essential-inputs-team@google.com" ],
+diff --git a/chrome/browser/flag-never-expire-list.json b/chrome/browser/flag-never-expire-list.json
+index 51f2b6772866c..b20893f0efd7c 100644
+--- a/chrome/browser/flag-never-expire-list.json
++++ b/chrome/browser/flag-never-expire-list.json
+@@ -27,6 +27,7 @@
+   "disable-explicit-dma-fences",
+   "disable-javascript-harmony-shipping",
+   "disable-threaded-scrolling",
++  "disable-v8-jit",
+   "disable-webrtc-hw-decoding",
+   "disable-webrtc-hw-encoding",
+   "disallow-doc-written-script-loads",
+diff --git a/chrome/browser/flag_descriptions.cc b/chrome/browser/flag_descriptions.cc
+index d41f7a9563b5a..bcdf7841afa8d 100644
+--- a/chrome/browser/flag_descriptions.cc
++++ b/chrome/browser/flag_descriptions.cc
+@@ -2636,6 +2636,11 @@ const char kUseSearchClickForRightClickDescription[] =
+     "webpages and apps to consume alt+click. When disabled the legacy "
+     "behavior of remapping alt+click to right click will remain unchanged.";
+ 
++const char kV8NoJITName[] = "Disable V8 JIT (JITless)";
++const char kV8NoJITDescription[] = 
++    "Experimental security mode that disables all runtime allocation of "
++    "executable memory";
++
+ const char kV8VmFutureName[] = "Future V8 VM features";
+ const char kV8VmFutureDescription[] =
+     "This enables upcoming and experimental V8 VM features. "
+diff --git a/chrome/browser/flag_descriptions.h b/chrome/browser/flag_descriptions.h
+index 1078cced42c52..ac5ee4b24e300 100644
+--- a/chrome/browser/flag_descriptions.h
++++ b/chrome/browser/flag_descriptions.h
+@@ -1496,6 +1496,9 @@ extern const char kUseFirstPartySetDescription[];
+ extern const char kUseSearchClickForRightClickName[];
+ extern const char kUseSearchClickForRightClickDescription[];
+ 
++extern const char kV8NoJITName[];
++extern const char kV8NoJITDescription[];
++
+ extern const char kV8VmFutureName[];
+ extern const char kV8VmFutureDescription[];
+ 
+diff --git a/gin/gin_features.cc b/gin/gin_features.cc
+index 55c519e5a142b..1eac910dba79f 100644
+--- a/gin/gin_features.cc
++++ b/gin/gin_features.cc
+@@ -47,6 +47,9 @@ const base::Feature kV8NoReclaimUnmodifiedWrappers{
+ const base::Feature kV8LocalHeaps{"V8LocalHeaps",
+                                   base::FEATURE_ENABLED_BY_DEFAULT};
+ 
++// Disables the V8 Just-in-Time compiler
++const base::Feature kV8NoJIT{"V8NoJIT", base::FEATURE_DISABLED_BY_DEFAULT};
++
+ // Enables TurboFan's direct heap access.
+ const base::Feature kV8TurboDirectHeapAccess{"V8TurboDirectHeapAccess",
+                                              base::FEATURE_ENABLED_BY_DEFAULT};
+diff --git a/gin/gin_features.h b/gin/gin_features.h
+index 2eb9e36d580c1..e7fdcbf55661f 100644
+--- a/gin/gin_features.h
++++ b/gin/gin_features.h
+@@ -18,6 +18,7 @@ GIN_EXPORT extern const base::Feature kV8FlushBytecode;
+ GIN_EXPORT extern const base::Feature kV8FlushEmbeddedBlobICache;
+ GIN_EXPORT extern const base::Feature kV8LazyFeedbackAllocation;
+ GIN_EXPORT extern const base::Feature kV8LocalHeaps;
++GIN_EXPORT extern const base::Feature kV8NoJIT;
+ GIN_EXPORT extern const base::Feature kV8NoReclaimUnmodifiedWrappers;
+ GIN_EXPORT extern const base::Feature kV8OffThreadFinalization;
+ GIN_EXPORT extern const base::Feature kV8OptimizeJavascript;
+diff --git a/gin/v8_initializer.cc b/gin/v8_initializer.cc
+index 6e7261ff6e7ea..8bdde491a709d 100644
+--- a/gin/v8_initializer.cc
++++ b/gin/v8_initializer.cc
+@@ -325,6 +325,10 @@ void V8Initializer::Initialize(IsolateHolder::ScriptMode mode) {
+     SetV8Flags("--no-local-heaps --no-turbo-direct-heap-access");
+   }
+ 
++  if (base::FeatureList::IsEnabled(features::kV8NoJIT)) {
++    SetV8Flags("--jitless");
++  }
++
+   if (!base::FeatureList::IsEnabled(features::kV8TurboDirectHeapAccess)) {
+     // The --turbo-direct-heap-access flag is enabled by default, so we need to
+     // explicitly disable it if kV8TurboDirectHeapAccess is disabled.
+-- 
+2.30.1 (Apple Git-130)
+


### PR DESCRIPTION
This patch adds initial support for disabling the V8 JIT with a flag in `chrome://flags`. I noticed a significant performance decrease in Speedometer 2.0 with the toggle on. (arm64, macOS).

Supersedes #34 & Closes #1 