### PR TITLE
Enable strict origin isolation by default

### DIFF
--- a/patches/0001-switch-to-fstack-protector-strong.patch
+++ b/patches/0001-switch-to-fstack-protector-strong.patch
@@ -1,7 +1,7 @@
 From 349f806706fa3b1e54a3d75fbe8bd7ca1f34e3e4 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 26 Dec 2018 10:20:24 -0500
-Subject: [PATCH 01/38] switch to -fstack-protector-strong
+Subject: [PATCH 01/39] switch to -fstack-protector-strong
 
 ---
  build/config/compiler/BUILD.gn | 6 +-----

--- a/patches/0002-enable-fwrapv-in-Clang-for-non-UBSan-builds.patch
+++ b/patches/0002-enable-fwrapv-in-Clang-for-non-UBSan-builds.patch
@@ -1,7 +1,7 @@
 From 302a2e0f399a45ad215b4c1f71b7eb5ac438ba66 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 22 Dec 2016 07:15:34 -0500
-Subject: [PATCH 02/38] enable -fwrapv in Clang for non-UBSan builds
+Subject: [PATCH 02/39] enable -fwrapv in Clang for non-UBSan builds
 
 ---
  build/config/compiler/BUILD.gn | 4 ++++

--- a/patches/0003-enable-ftrivial-auto-var-init-zero.patch
+++ b/patches/0003-enable-ftrivial-auto-var-init-zero.patch
@@ -1,7 +1,7 @@
 From 47eaeb71fbb1b21b9b894677a3b201cdc1f6027f Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 8 Apr 2020 20:48:17 -0400
-Subject: [PATCH 03/38] enable -ftrivial-auto-var-init=zero
+Subject: [PATCH 03/39] enable -ftrivial-auto-var-init=zero
 
 ---
  build/config/compiler/BUILD.gn | 4 ++++

--- a/patches/0004-disable-broken-warning-for-auto-var-init.patch
+++ b/patches/0004-disable-broken-warning-for-auto-var-init.patch
@@ -1,7 +1,7 @@
 From 761871f28d0fee5407031071b9b37126f5b86468 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 21 May 2020 14:07:54 -0400
-Subject: [PATCH 04/38] disable broken warning for auto var init
+Subject: [PATCH 04/39] disable broken warning for auto var init
 
 ---
  build/config/compiler/BUILD.gn | 2 +-

--- a/patches/0005-disable-seed-based-field-trials.patch
+++ b/patches/0005-disable-seed-based-field-trials.patch
@@ -1,7 +1,7 @@
 From bc89209a23264a191d06b704f8b2f8a7b4d72086 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 25 Dec 2018 16:19:51 -0500
-Subject: [PATCH 05/38] disable seed-based field trials
+Subject: [PATCH 05/39] disable seed-based field trials
 
 ---
  components/variations/service/variations_field_trial_creator.cc | 2 ++

--- a/patches/0006-disable-navigation-error-correction-by-default.patch
+++ b/patches/0006-disable-navigation-error-correction-by-default.patch
@@ -1,7 +1,7 @@
 From 0484a5b95e23cce1f1765ab90ace1b13819c075e Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 23 Nov 2016 08:29:58 -0500
-Subject: [PATCH 06/38] disable navigation error correction by default
+Subject: [PATCH 06/39] disable navigation error correction by default
 
 ---
  chrome/browser/net/profile_network_context_service.cc | 2 +-

--- a/patches/0007-disable-network-prediction-by-default.patch
+++ b/patches/0007-disable-network-prediction-by-default.patch
@@ -1,7 +1,7 @@
 From 348b21caa4427203700ceb12e44a1bae2584de91 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 23 Nov 2016 08:31:44 -0500
-Subject: [PATCH 07/38] disable network prediction by default
+Subject: [PATCH 07/39] disable network prediction by default
 
 ---
  chrome/browser/net/prediction_options.h | 2 +-

--- a/patches/0008-disable-hyperlink-auditing-by-default.patch
+++ b/patches/0008-disable-hyperlink-auditing-by-default.patch
@@ -1,7 +1,7 @@
 From fa174f0a796696476da755cd0dde170fbc772c26 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sat, 26 Nov 2016 14:57:22 -0500
-Subject: [PATCH 08/38] disable hyperlink auditing by default
+Subject: [PATCH 08/39] disable hyperlink auditing by default
 
 ---
  chrome/browser/chrome_content_browser_client.cc | 2 +-

--- a/patches/0009-disable-showing-popular-sites-by-default.patch
+++ b/patches/0009-disable-showing-popular-sites-by-default.patch
@@ -1,7 +1,7 @@
 From 7828b30f91516e6643c88a62a4d828aa3d5332fc Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 6 Mar 2018 00:27:41 -0500
-Subject: [PATCH 09/38] disable showing popular sites by default
+Subject: [PATCH 09/39] disable showing popular sites by default
 
 ---
  components/ntp_tiles/features.cc | 4 ++--

--- a/patches/0010-disable-article-suggestions-feature-by-default.patch
+++ b/patches/0010-disable-article-suggestions-feature-by-default.patch
@@ -1,7 +1,7 @@
 From 8c4db78cec08d9fd9b0855ed670df4ea6a58b979 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 8 Mar 2018 22:43:12 -0500
-Subject: [PATCH 10/38] disable article suggestions feature by default
+Subject: [PATCH 10/39] disable article suggestions feature by default
 
 ---
  components/feed/core/shared_prefs/pref_names.cc | 4 ++--

--- a/patches/0011-disable-prefetching-suggested-pages-by-default.patch
+++ b/patches/0011-disable-prefetching-suggested-pages-by-default.patch
@@ -1,7 +1,7 @@
 From 95bada4637746d7d95b99db4db7b44fa7515a428 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 12 Jul 2019 04:10:21 -0400
-Subject: [PATCH 11/38] disable prefetching suggested pages by default
+Subject: [PATCH 11/39] disable prefetching suggested pages by default
 
 ---
  components/offline_pages/core/offline_page_feature.cc | 2 +-

--- a/patches/0012-disable-sensors-access-by-default.patch
+++ b/patches/0012-disable-sensors-access-by-default.patch
@@ -1,7 +1,7 @@
 From 5b2b229b09082596e3f3a49a01dc90e925e44ab1 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 16 Jun 2019 15:57:29 -0400
-Subject: [PATCH 12/38] disable sensors access by default
+Subject: [PATCH 12/39] disable sensors access by default
 
 ---
  .../content_settings/core/browser/content_settings_registry.cc  | 2 +-

--- a/patches/0013-disable-third-party-cookies-by-default.patch
+++ b/patches/0013-disable-third-party-cookies-by-default.patch
@@ -1,7 +1,7 @@
 From d35b91e4bef0bfa37ddb9aada4b2129b89b8b5b8 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 16 Jun 2019 16:01:31 -0400
-Subject: [PATCH 13/38] disable third party cookies by default
+Subject: [PATCH 13/39] disable third party cookies by default
 
 ---
  components/content_settings/core/browser/cookie_settings.cc | 2 +-

--- a/patches/0014-disable-background-sync-by-default.patch
+++ b/patches/0014-disable-background-sync-by-default.patch
@@ -1,7 +1,7 @@
 From 478b2d1ac6ce13aa75707fd57a05f7943821cb26 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 16 Jun 2019 21:57:26 -0400
-Subject: [PATCH 14/38] disable background sync by default
+Subject: [PATCH 14/39] disable background sync by default
 
 ---
  .../content_settings/core/browser/content_settings_registry.cc  | 2 +-

--- a/patches/0015-disable-payment-support-by-default.patch
+++ b/patches/0015-disable-payment-support-by-default.patch
@@ -1,7 +1,7 @@
 From 5776618d238215271129e2ce0ba5477c29baebd4 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 18 Jun 2019 22:28:53 -0400
-Subject: [PATCH 15/38] disable payment support by default
+Subject: [PATCH 15/39] disable payment support by default
 
 ---
  components/payments/core/payment_prefs.cc | 2 +-

--- a/patches/0016-disable-media-router-media-remoting-by-default.patch
+++ b/patches/0016-disable-media-router-media-remoting-by-default.patch
@@ -1,7 +1,7 @@
 From c0498ce0c1866270a372b2cb8fa5531f11c57d24 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 4 Jul 2019 18:11:27 -0400
-Subject: [PATCH 16/38] disable media router media remoting by default
+Subject: [PATCH 16/39] disable media router media remoting by default
 
 ---
  chrome/browser/profiles/profile.cc | 2 +-

--- a/patches/0017-disable-media-router-by-default.patch
+++ b/patches/0017-disable-media-router-by-default.patch
@@ -1,7 +1,7 @@
 From 7556d9468245f9873982c3bc9b5ecc9ce39f8abb Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 4 Jul 2019 19:08:52 -0400
-Subject: [PATCH 17/38] disable media router by default
+Subject: [PATCH 17/39] disable media router by default
 
 ---
  chrome/browser/media/router/media_router_feature.cc | 2 +-

--- a/patches/0018-disable-offering-translations-by-default.patch
+++ b/patches/0018-disable-offering-translations-by-default.patch
@@ -1,7 +1,7 @@
 From 80848ee9ad3dfdd627d0eaaf2a17542305db95a4 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 12 Jul 2019 03:58:01 -0400
-Subject: [PATCH 18/38] disable offering translations by default
+Subject: [PATCH 18/39] disable offering translations by default
 
 ---
  chrome/browser/ui/browser_ui_prefs.cc | 2 +-

--- a/patches/0019-disable-browser-sign-in-feature-by-default.patch
+++ b/patches/0019-disable-browser-sign-in-feature-by-default.patch
@@ -1,7 +1,7 @@
 From f3add8f3a8eed59887c821fd7d66bb3774388bbb Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 12 Jul 2019 04:23:18 -0400
-Subject: [PATCH 19/38] disable browser sign in feature by default
+Subject: [PATCH 19/39] disable browser sign in feature by default
 
 ---
  chrome/browser/signin/account_consistency_mode_manager.cc       | 2 +-

--- a/patches/0020-disable-browser-autologin-by-default.patch
+++ b/patches/0020-disable-browser-autologin-by-default.patch
@@ -1,7 +1,7 @@
 From ed6011bd5ed55dab81b33637c6804a5733b2b524 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 22 Mar 2020 03:07:08 -0400
-Subject: [PATCH 20/38] disable browser autologin by default
+Subject: [PATCH 20/39] disable browser autologin by default
 
 ---
  .../signin/internal/identity_manager/primary_account_manager.cc | 2 +-

--- a/patches/0021-disable-safe-browsing-reporting-opt-in-by-default.patch
+++ b/patches/0021-disable-safe-browsing-reporting-opt-in-by-default.patch
@@ -1,7 +1,7 @@
 From 5ced68143094115c0a76ba5a5c83fa8ef38f004e Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 12 Jul 2019 05:22:11 -0400
-Subject: [PATCH 21/38] disable safe browsing reporting opt-in by default
+Subject: [PATCH 21/39] disable safe browsing reporting opt-in by default
 
 ---
  components/safe_browsing/core/common/safe_browsing_prefs.cc | 2 +-

--- a/patches/0022-disable-unused-safe-browsing-option-by-default.patch
+++ b/patches/0022-disable-unused-safe-browsing-option-by-default.patch
@@ -1,7 +1,7 @@
 From 7b1434832648d3acc12684eff2d178b8155785f4 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 12 Mar 2020 13:01:02 -0400
-Subject: [PATCH 22/38] disable unused safe browsing option by default
+Subject: [PATCH 22/39] disable unused safe browsing option by default
 
 Safe Browsing is currently a no-op due to the lack of Play Services, and
 support for using the local database backend hasn't been implemented.

--- a/patches/0023-enable-prefetch-privacy-changes-by-default.patch
+++ b/patches/0023-enable-prefetch-privacy-changes-by-default.patch
@@ -1,7 +1,7 @@
 From 9e10a998ef47eb6816182a19768a0a9c41cee8bf Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 23 Oct 2020 23:59:13 -0400
-Subject: [PATCH 23/38] enable prefetch privacy changes by default
+Subject: [PATCH 23/39] enable prefetch privacy changes by default
 
 ---
  third_party/blink/common/features.cc | 2 +-

--- a/patches/0024-enable-user-agent-freeze-by-default.patch
+++ b/patches/0024-enable-user-agent-freeze-by-default.patch
@@ -1,7 +1,7 @@
 From 5e28b921a3e0dc124c53adf5a4946a8e348ee9ff Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 3 Mar 2021 13:42:41 -0500
-Subject: [PATCH 24/38] enable user agent freeze by default
+Subject: [PATCH 24/39] enable user agent freeze by default
 
 ---
  third_party/blink/common/features.cc | 2 +-

--- a/patches/0025-enable-split-cache-by-default.patch
+++ b/patches/0025-enable-split-cache-by-default.patch
@@ -1,7 +1,7 @@
 From fa21c0b22ba63d2057cac96d2b91be6da7cdac76 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 23 Dec 2020 06:00:50 -0500
-Subject: [PATCH 25/38] enable split cache by default
+Subject: [PATCH 25/39] enable split cache by default
 
 ---
  net/base/features.cc | 2 +-

--- a/patches/0026-enable-partitioning-connections-by-default.patch
+++ b/patches/0026-enable-partitioning-connections-by-default.patch
@@ -1,7 +1,7 @@
 From b886ec670ffbf20bb047d1622bf93fe05d3e7648 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Mon, 8 Mar 2021 16:53:47 -0500
-Subject: [PATCH 26/38] enable partitioning connections by default
+Subject: [PATCH 26/39] enable partitioning connections by default
 
 ---
  net/base/features.cc | 12 ++++++------

--- a/patches/0027-enable-dubious-Do-Not-Track-feature-by-default.patch
+++ b/patches/0027-enable-dubious-Do-Not-Track-feature-by-default.patch
@@ -1,7 +1,7 @@
 From 99508f5c9df2fc06c8cc7ee4d759f3a028ee2fb1 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 1 Aug 2017 11:16:11 -0400
-Subject: [PATCH 27/38] enable dubious Do Not Track feature by default
+Subject: [PATCH 27/39] enable dubious Do Not Track feature by default
 
 ---
  chrome/browser/ui/browser_ui_prefs.cc | 2 +-

--- a/patches/0028-disable-autofill-server-communication-by-default.patch
+++ b/patches/0028-disable-autofill-server-communication-by-default.patch
@@ -1,7 +1,7 @@
 From 3b4a0114b42e721df18f5c9566065e2ebe40ad1e Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 1 Dec 2020 00:56:57 -0500
-Subject: [PATCH 28/38] disable autofill server communication by default
+Subject: [PATCH 28/39] disable autofill server communication by default
 
 ---
  components/autofill/core/common/autofill_features.cc | 2 +-

--- a/patches/0029-disable-component-updater-pings-by-default.patch
+++ b/patches/0029-disable-component-updater-pings-by-default.patch
@@ -1,7 +1,7 @@
 From 0a8fd6f07eb1eda38589fd2adaeb50938197afdc Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 27 Nov 2020 03:56:29 -0500
-Subject: [PATCH 29/38] disable component updater pings by default
+Subject: [PATCH 29/39] disable component updater pings by default
 
 ---
  .../component_updater_command_line_config_policy.h              | 2 +-

--- a/patches/0030-mark-non-secure-origins-as-dangerous.patch
+++ b/patches/0030-mark-non-secure-origins-as-dangerous.patch
@@ -1,7 +1,7 @@
 From 6bd0370e418d4046d221155f2e3720cef15965f6 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 20 Oct 2017 21:20:50 -0400
-Subject: [PATCH 30/38] mark non-secure origins as dangerous
+Subject: [PATCH 30/39] mark non-secure origins as dangerous
 
 ---
  components/security_state/core/security_state.cc | 2 +-

--- a/patches/0031-stub-out-the-battery-status-API.patch
+++ b/patches/0031-stub-out-the-battery-status-API.patch
@@ -1,7 +1,7 @@
 From 2ff0f7ea22b5e7a584a4f16c7ab9fbcebc86d21a Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Mon, 17 Jun 2019 11:29:21 -0400
-Subject: [PATCH 31/38] stub out the battery status API
+Subject: [PATCH 31/39] stub out the battery status API
 
 Pretend that the device is always plugged in and fully charged.
 ---

--- a/patches/0032-always-use-local-new-tab-page.patch
+++ b/patches/0032-always-use-local-new-tab-page.patch
@@ -1,7 +1,7 @@
 From c9150bb895a10584b4599fa8fa08c67c1728a44f Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Mon, 17 Jun 2019 13:14:22 -0400
-Subject: [PATCH 32/38] always use local new tab page
+Subject: [PATCH 32/39] always use local new tab page
 
 ---
  chrome/browser/search/search.cc | 2 +-

--- a/patches/0033-disable-trivial-subdomain-hiding.patch
+++ b/patches/0033-disable-trivial-subdomain-hiding.patch
@@ -1,7 +1,7 @@
 From 8e127966544ccb175f02827ea54779783f99bf5e Mon Sep 17 00:00:00 2001
 From: JTL <jtl@teamclassified.ca>
 Date: Sat, 21 Dec 2019 04:04:24 +0000
-Subject: [PATCH 33/38] disable trivial subdomain hiding
+Subject: [PATCH 33/39] disable trivial subdomain hiding
 
 ---
  components/url_formatter/url_formatter.cc | 3 +--

--- a/patches/0034-disable-trials-of-privacy-aware-analytics-advertisin.patch
+++ b/patches/0034-disable-trials-of-privacy-aware-analytics-advertisin.patch
@@ -1,7 +1,7 @@
 From 5bf48e98cf29f82008830def673319c34b0a6e2e Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 4 Aug 2021 03:29:04 -0400
-Subject: [PATCH 34/38] disable trials of privacy-aware analytics/advertising
+Subject: [PATCH 34/39] disable trials of privacy-aware analytics/advertising
  APIs
 
 ---

--- a/patches/0035-Hexavalent-set-webrtc-to-private-but-usable-default.patch
+++ b/patches/0035-Hexavalent-set-webrtc-to-private-but-usable-default.patch
@@ -1,7 +1,7 @@
 From e1afd9c9ebfbccb73a653429ae93cd5c7a924c67 Mon Sep 17 00:00:00 2001
 From: flawedworld <flawedworld@flawed.world>
 Date: Sat, 14 Aug 2021 19:47:24 +0100
-Subject: [PATCH 35/38] Hexavalent: set webrtc to private but usable default
+Subject: [PATCH 35/39] Hexavalent: set webrtc to private but usable default
 
 ---
  chrome/browser/ui/browser_ui_prefs.cc | 2 +-

--- a/patches/0036-Debian-disable-the-google-api-key-warning-when-those.patch
+++ b/patches/0036-Debian-disable-the-google-api-key-warning-when-those.patch
@@ -1,7 +1,7 @@
 From be6fca3200e29a5775540670a32e6a6bc491da15 Mon Sep 17 00:00:00 2001
 From: Michael Gilbert <mgilbert@debian.org>
 Date: Sun, 15 Aug 2021 05:08:49 +0100
-Subject: [PATCH 36/38] Debian: disable the google api key warning when those
+Subject: [PATCH 36/39] Debian: disable the google api key warning when those
  aren't found
 
 ---

--- a/patches/0037-Hexavalent-Make-HTTPS-only-mode-the-default.patch
+++ b/patches/0037-Hexavalent-Make-HTTPS-only-mode-the-default.patch
@@ -1,7 +1,7 @@
 From d9a173b1dc6c1e3cd4164516223b84d0cdbe9c31 Mon Sep 17 00:00:00 2001
 From: qua3k <cliffmaceyak@gmail.com>
 Date: Mon, 18 Oct 2021 17:18:52 -0400
-Subject: [PATCH 37/38] Hexavalent: Make HTTPS-only mode the default
+Subject: [PATCH 37/39] Hexavalent: Make HTTPS-only mode the default
 
 ---
  chrome/browser/ui/browser_ui_prefs.cc | 2 +-

--- a/patches/0038-Initial-support-for-disabling-V8-s-JIT.patch
+++ b/patches/0038-Initial-support-for-disabling-V8-s-JIT.patch
@@ -1,7 +1,7 @@
 From dfaa41bc5359d32c2f78706210ae85b44d301408 Mon Sep 17 00:00:00 2001
 From: qua3k <cliffmaceyak@gmail.com>
 Date: Tue, 19 Oct 2021 07:36:10 -0400
-Subject: [PATCH 38/38] Initial support for disabling V8's JIT
+Subject: [PATCH 38/39] Initial support for disabling V8's JIT
 
 This adds a flag in `chrome://flags` for toggling the V8 JIT
 compiler; it is default disabled.

--- a/patches/0039-Enable-strict-origin-isolation-by-default.patch
+++ b/patches/0039-Enable-strict-origin-isolation-by-default.patch
@@ -1,0 +1,32 @@
+From 66e994b635179c5c4eee9b003ccdbf5ea6fed90b Mon Sep 17 00:00:00 2001
+From: qua3k <cliffmaceyak@gmail.com>
+Date: Thu, 21 Oct 2021 17:44:31 -0400
+Subject: [PATCH 39/39] Enable strict origin isolation by default
+
+Upstream is in the process of enabling origin isolation by default
+in the process of deprecating `document.domain`. An insignificant
+number of Chrome page loads use `document.domain`.
+
+See https://crbug.com/1259920 and
+https://chromestatus.com/metrics/feature/timeline/popularity/2544
+for more detail.
+---
+ content/public/common/content_features.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/content/public/common/content_features.cc b/content/public/common/content_features.cc
+index 25197c9010758..d927d05d51e18 100644
+--- a/content/public/common/content_features.cc
++++ b/content/public/common/content_features.cc
+@@ -833,7 +833,7 @@ const base::Feature kStorageServiceOutOfProcess{
+ // Controls whether site isolation should use origins instead of scheme and
+ // eTLD+1.
+ const base::Feature kStrictOriginIsolation{"StrictOriginIsolation",
+-                                           base::FEATURE_DISABLED_BY_DEFAULT};
++                                           base::FEATURE_ENABLED_BY_DEFAULT};
+ 
+ // Enables subresource loading with Web Bundles.
+ const base::Feature kSubresourceWebBundles{"SubresourceWebBundles",
+-- 
+2.30.1 (Apple Git-130)
+


### PR DESCRIPTION
Upstream is in the process of enabling origin isolation by default
in the process of deprecating `document.domain`. An insignificant
number of Chrome page loads use `document.domain`.

See https://crbug.com/1259920 and
https://chromestatus.com/metrics/feature/timeline/popularity/2544
for more detail.